### PR TITLE
fix(workflow): update checkout action to v4 and ensure full history i…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,9 @@ jobs:
       issues: 'write'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4 # Update to v4
+        with:
+          fetch-depth: 0 # Ensure full history is fetched
 
       - name: Set up Node.js
         uses: actions/setup-node@v3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,21 +147,22 @@ The project follows a structured process from development to production, using a
    - **Important:** Use either **"Create a merge commit"** or **"Rebase and merge"**. Do **NOT** use "Squash and merge", as this will prevent `semantic-release` from correctly determining the version and generating release notes.
 
 4. **Release Tagging:**
-   - After merging to `main`, a repository maintainer will manually create a tag starting with `release-` to trigger the release process:
+   - After merging to `main`, a repository maintainer will manually create a tag starting with `release-` followed by a timestamp to trigger the release process. This tag *only* triggers the workflow; `semantic-release` will calculate and create the actual version tag (e.g., `v1.1.0`).
      ```bash
      git checkout main
      git pull
-     # Example: git tag -a release-v0.1.0 -m "Initial release"
-     git tag -a release-<version> -m "Release <version>"
-     git push origin release-<version>
+     # Create a timestamp-based tag like release-20250418103000
+     TIMESTAMP=$(date +%Y%m%d%H%M%S)
+     git tag -a release-${TIMESTAMP} -m "Triggering release workflow"
+     git push origin release-${TIMESTAMP}
      ```
-   - The GitHub workflow is triggered when a tag matching `release-*` is pushed.
-   - Once triggered, semantic-release will:
-     - Analyze the commits since the last release
-     - Determine the appropriate version number based on conventional commits
-     - Generate release notes automatically from commit messages
-     - Create a GitHub release with the determined version (independent of your manually created tag)
-     - Publish the package to npm (if configured)
+   - The GitHub workflow (`release.yml`) is triggered when a tag matching `release-*` is pushed.
+   - Once triggered, `semantic-release` will:
+     - Analyze the commits on `main` since the last actual version tag (e.g., `v1.0.0`).
+     - Determine the appropriate next version number based on conventional commits.
+     - Generate release notes automatically from commit messages.
+     - Create a GitHub release and a corresponding version tag (e.g., `v1.1.0`).
+     - Publish the package to npm with the calculated version.
 
 5. **Test Publishing:**  
    For test releases, use the `.github/workflows/test-publish.yml` workflow, which can be triggered manually from the Actions tab. Test packages are published to npm with a tag like `1.2.3-YYYYMMDD-beta`.

--- a/package.json
+++ b/package.json
@@ -98,8 +98,7 @@
             "@semantic-release/release-notes-generator",
             "@semantic-release/changelog",
             "@semantic-release/npm",
-            "@semantic-release/github",
-            "@semantic-release/git"
+            "@semantic-release/github"
         ]
     },
     "config": {


### PR DESCRIPTION
…s fetched

This pull request includes updates to the GitHub Actions workflow, documentation, and dependencies to improve the release process and streamline project maintenance. The most important changes include upgrading the `actions/checkout` version, revising the release tagging process in the documentation, and removing an unused dependency from `package.json`.

### Workflow Improvements:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L22-R24): Upgraded `actions/checkout` to version 4 and added the `fetch-depth: 0` configuration to ensure the full repository history is fetched. This is important for workflows that depend on the complete commit history.

### Documentation Updates:
* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L150-R165): Revised the release tagging process to use timestamp-based tags (e.g., `release-20250418103000`) instead of version-based tags. Clarified that `semantic-release` will calculate the actual version tag and handle the release process, including generating release notes and publishing to npm.

### Dependency Cleanup:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L101-R101): Removed the `@semantic-release/git` plugin from the list of release-related dependencies, as it is no longer required for the release process.