### PR TITLE
fix(ci): resolve tag conflict in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,9 @@ jobs:
       issues: 'write'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4 # Update to v4
+        uses: actions/checkout@v4
         with:
+          ref: main # Explicitly check out the main branch
           fetch-depth: 0 # Ensure full history is fetched
 
       - name: Set up Node.js


### PR DESCRIPTION
Workflow configuration updates:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L22-R24): Updated the `Checkout Repository` step to explicitly check out the `main` branch by adding `ref: main` under the `with` section. This ensures that the workflow operates on the correct branch.