### PR TITLE
fix(workflow): update release trigger to use main branch instead of tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-    tags:
-      - 'release-*'  # triggers on release tagged commits
+    branches:
+      - main # Trigger on pushes to the main branch
 
 jobs:
   release:
@@ -21,7 +21,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref: main # Explicitly check out the main branch
           fetch-depth: 0 # Ensure full history is fetched
 
       - name: Set up Node.js

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,26 +145,15 @@ The project follows a structured process from development to production, using a
    - A repository maintainer will run final verification on the release candidate.
    - Once approved, a repository maintainer will merge the pull request to `main`.
    - **Important:** Use either **"Create a merge commit"** or **"Rebase and merge"**. Do **NOT** use "Squash and merge", as this will prevent `semantic-release` from correctly determining the version and generating release notes.
-
-4. **Release Tagging:**
-   - After merging to `main`, a repository maintainer will manually create a tag starting with `release-` followed by a timestamp to trigger the release process. This tag *only* triggers the workflow; `semantic-release` will calculate and create the actual version tag (e.g., `v1.1.0`).
-     ```bash
-     git checkout main
-     git pull
-     # Create a timestamp-based tag like release-20250418103000
-     TIMESTAMP=$(date +%Y%m%d%H%M%S)
-     git tag -a release-${TIMESTAMP} -m "Triggering release workflow"
-     git push origin release-${TIMESTAMP}
-     ```
-   - The GitHub workflow (`release.yml`) is triggered when a tag matching `release-*` is pushed.
-   - Once triggered, `semantic-release` will:
-     - Analyze the commits on `main` since the last actual version tag (e.g., `v1.0.0`).
+   - Merging to `main` will automatically trigger the `release.yml` workflow.
+   - `semantic-release` will then:
+     - Analyze the commits on `main` since the last release tag.
      - Determine the appropriate next version number based on conventional commits.
      - Generate release notes automatically from commit messages.
      - Create a GitHub release and a corresponding version tag (e.g., `v1.1.0`).
      - Publish the package to npm with the calculated version.
 
-5. **Test Publishing:**  
+4. **Test Publishing:**  
    For test releases, use the `.github/workflows/test-publish.yml` workflow, which can be triggered manually from the Actions tab. Test packages are published to npm with a tag like `1.2.3-YYYYMMDD-beta`.
 
    To install a package published with a specific tag (e.g., `beta`):


### PR DESCRIPTION
This pull request updates the release workflow to simplify the process by triggering releases automatically on pushes to the `main` branch, instead of relying on manual tagging. It also updates the documentation in `CONTRIBUTING.md` to reflect this streamlined workflow.

### Workflow Changes:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L5-R6): Updated the trigger condition to run the release workflow on pushes to the `main` branch instead of tags matching `release-*`. Removed the explicit checkout of the `main` branch in the workflow. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L5-R6) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L24)

### Documentation Updates:
* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L148-R156): Removed the section on manual release tagging and updated the release process description to reflect the automatic triggering of the release workflow on merges to `main`. Clarified that `semantic-release` will handle versioning and release note generation.