### PR TITLE
Develop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   push:
-    tags:
-      - 'release-*'  # triggers on release tagged commits
+    branches:
+      - main # Trigger on pushes to the main branch
 
 jobs:
   release:
@@ -21,7 +21,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref: main # Explicitly check out the main branch
           fetch-depth: 0 # Ensure full history is fetched
 
       - name: Set up Node.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'  # triggers on version tagged commits
+      - 'release-*'  # triggers on release tagged commits
 
 jobs:
   release:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,26 +145,15 @@ The project follows a structured process from development to production, using a
    - A repository maintainer will run final verification on the release candidate.
    - Once approved, a repository maintainer will merge the pull request to `main`.
    - **Important:** Use either **"Create a merge commit"** or **"Rebase and merge"**. Do **NOT** use "Squash and merge", as this will prevent `semantic-release` from correctly determining the version and generating release notes.
-
-4. **Release Tagging:**
-   - After merging to `main`, a repository maintainer will manually create a tag starting with `release-` followed by a timestamp to trigger the release process. This tag *only* triggers the workflow; `semantic-release` will calculate and create the actual version tag (e.g., `v1.1.0`).
-     ```bash
-     git checkout main
-     git pull
-     # Create a timestamp-based tag like release-20250418103000
-     TIMESTAMP=$(date +%Y%m%d%H%M%S)
-     git tag -a release-${TIMESTAMP} -m "Triggering release workflow"
-     git push origin release-${TIMESTAMP}
-     ```
-   - The GitHub workflow (`release.yml`) is triggered when a tag matching `release-*` is pushed.
-   - Once triggered, `semantic-release` will:
-     - Analyze the commits on `main` since the last actual version tag (e.g., `v1.0.0`).
+   - Merging to `main` will automatically trigger the `release.yml` workflow.
+   - `semantic-release` will then:
+     - Analyze the commits on `main` since the last release tag.
      - Determine the appropriate next version number based on conventional commits.
      - Generate release notes automatically from commit messages.
      - Create a GitHub release and a corresponding version tag (e.g., `v1.1.0`).
      - Publish the package to npm with the calculated version.
 
-5. **Test Publishing:**  
+4. **Test Publishing:**  
    For test releases, use the `.github/workflows/test-publish.yml` workflow, which can be triggered manually from the Actions tab. Test packages are published to npm with a tag like `1.2.3-YYYYMMDD-beta`.
 
    To install a package published with a specific tag (e.g., `beta`):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,14 +146,15 @@ The project follows a structured process from development to production, using a
    - Once approved, a repository maintainer will merge the pull request to `main`.
 
 4. **Release Tagging:**
-   - After merging to `main`, a repository maintainer will manually create a tag to trigger the release process:
+   - After merging to `main`, a repository maintainer will manually create a tag starting with `release-` to trigger the release process:
      ```bash
      git checkout main
      git pull
-     git tag -a v0.1.0 -m "Initial release"  # Or appropriate version
-     git push origin v0.1.0
+     # Example: git tag -a release-v0.1.0 -m "Initial release"
+     git tag -a release-<version> -m "Release <version>"
+     git push origin release-<version>
      ```
-   - The GitHub workflow is triggered when a tag matching `v*` is pushed.
+   - The GitHub workflow is triggered when a tag matching `release-*` is pushed.
    - Once triggered, semantic-release will:
      - Analyze the commits since the last release
      - Determine the appropriate version number based on conventional commits

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,6 +144,7 @@ The project follows a structured process from development to production, using a
    - This PR represents a release candidate.
    - A repository maintainer will run final verification on the release candidate.
    - Once approved, a repository maintainer will merge the pull request to `main`.
+   - **Important:** Use either **"Create a merge commit"** or **"Rebase and merge"**. Do **NOT** use "Squash and merge", as this will prevent `semantic-release` from correctly determining the version and generating release notes.
 
 4. **Release Tagging:**
    - After merging to `main`, a repository maintainer will manually create a tag starting with `release-` to trigger the release process:

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -1,6 +1,5 @@
 import { jest, expect, describe, it, beforeEach, afterEach } from '@jest/globals';
 import * as fs from 'fs/promises';
-import * as path from 'path';
 import * as crypto from 'crypto';
 import { configureOciCli, OciConfig } from '../main';
 import { Platform, PlatformLogger } from '../platforms/types';


### PR DESCRIPTION
This pull request updates the release workflow to simplify and automate the process by triggering releases on pushes to the `main` branch instead of using manual tagging. It also updates the documentation to reflect these changes. Below are the most important changes:

### Workflow Automation Changes:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L5-R6): Modified the trigger from `release-*` tags to pushes on the `main` branch, streamlining the release process.

### Documentation Updates:
* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L148-R156): Removed instructions for manually creating `release-*` tags and updated the release process to reflect the automated trigger on `main`. This ensures consistency with the updated workflow.

### Minor Adjustments:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L22-R22): Removed a redundant comment about updating to `actions/checkout@v4` since it is already in use.