### PR TITLE
build(workflow): add step to update latest tag in release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,3 +39,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Update latest tag # Add this step
+        run: |
+          git tag -f latest
+          git push --force origin latest
+        env:
+          # Use the same token semantic-release uses for authentication
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request adds a new step to the release workflow in `.github/workflows/release.yml` to update the `latest` tag after a release.

**Changes to the release workflow:**

* Added a new step named "Update latest tag" that force-updates the `latest` tag and pushes it to the remote repository. This step uses the `GITHUB_TOKEN` for authentication. (`[.github/workflows/release.ymlR42-R49](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R42-R49)`)