### PR TITLE
chore : recon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,9 @@ jobs:
       issues: 'write'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4 # Update to v4
+        uses: actions/checkout@v4
         with:
+          ref: main # Explicitly check out the main branch
           fetch-depth: 0 # Ensure full history is fetched
 
       - name: Set up Node.js


### PR DESCRIPTION
This pull request includes a small update to the `.github/workflows/release.yml` file. The change ensures that the workflow explicitly checks out the `main` branch during the "Checkout Repository" step.