### PR TITLE
Develop with fixed release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         id: semantic # Add an ID to reference the output
         run: npx semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_PAT }} # Changed from GITHUB_TOKEN
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # Add steps to update major version tag
@@ -57,21 +57,30 @@ jobs:
           MAJOR_VERSION=$(echo $RELEASE_VERSION | sed -E 's/v([0-9]+)\..*/\1/')
           MAJOR_TAG="v$MAJOR_VERSION"
           echo "Updating tag $MAJOR_TAG to point to $RELEASE_VERSION"
+          # Configure git user for this push
+          git config --global user.name "semantic-release-bot"
+          git config --global user.email "semantic-release-bot@users.noreply.github.com"
           # Create or update the major version tag locally, pointing to the same commit as the release version tag
           git tag -f $MAJOR_TAG $RELEASE_VERSION 
           # Force push the major version tag to the remote
-          git push --force origin $MAJOR_TAG
+          git push --force https://x-access-token:${{ secrets.SEMANTIC_RELEASE_PAT }}@github.com/${{ github.repository }} $MAJOR_TAG
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN is not directly used by git push here, explicit token in URL
+          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+
 
       - name: Update latest tag
         # Only run if a new version was released (RELEASE_VERSION is set)
         if: env.RELEASE_VERSION 
         run: |
           echo "Updating latest tag to point to $RELEASE_VERSION"
+          # Configure git user for this push (if not already done globally in job)
+          git config --global user.name "semantic-release-bot"
+          git config --global user.email "semantic-release-bot@users.noreply.github.com"
           # Create or update the latest tag locally, pointing it to the same commit as the release version tag
           git tag -f latest $RELEASE_VERSION 
           # Force push the latest tag to the remote
-          git push --force origin latest
+          git push --force https://x-access-token:${{ secrets.SEMANTIC_RELEASE_PAT }}@github.com/${{ github.repository }} latest
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN is not directly used by git push here, explicit token in URL
+          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ The project follows a structured process from development to production, using a
    - Merging to `main` will automatically trigger:
      1. The `build-and-commit.yml` workflow (ensures `dist/` is current)
      2. The `release.yml` workflow (handles versioning and publishing)
-   - `semantic-release` will then:
+     3. `semantic-release` will then:
      - Analyze the commits on `main` since the last release tag (using rules from `.releaserc.json`).
      - Determine the appropriate next version number based on conventional commits.
      - Generate release notes automatically from commit messages.


### PR DESCRIPTION
This pull request includes updates to the release workflow and documentation to improve token usage security and clarify the release process. The most important changes involve switching to a more secure token for semantic release operations and enhancing documentation for better understanding of the release process.

### Release Workflow Updates:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L42-R42): Replaced `GITHUB_TOKEN` with `SEMANTIC_RELEASE_PAT` for semantic release operations to improve security. Updated the `git push` commands to include the explicit token in the URL. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L42-R42) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R60-R86)
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R60-R86): Added global git user configuration (`semantic-release-bot`) to ensure consistent commit attribution during tag updates.

### Documentation Enhancements:
* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L157-R157): Clarified the release process by explicitly listing `semantic-release` as the third step in the workflow triggered by merging to `main`.