### PR TITLE
Develop - streamline CI/CD processes and improve automation

### DIFF
--- a/.github/workflows/build-and-commit.yml
+++ b/.github/workflows/build-and-commit.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
       - develop
+  pull_request: # Add this
+    branches:   # Add this
+      - main    # Add this
+      - develop # Add this
 
 jobs:
   build:
@@ -26,11 +30,17 @@ jobs:
     # 4. Builds your action using ncc (creates dist/main.js and dist/cli.js)
     - run: npm run build
     
+    # Run tests
+    - name: Run tests
+      run: npm test
+      
     # 5. Commits the built files back to the repository
+    # Only run this step on push events, not on pull_request events
     - name: Commit built files
+      if: github.event_name == 'push' 
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git add dist/                                    # Stage the built files
-        git diff --staged --quiet || git commit -m "Build dist files"  # Only commit if changes exist
-        git push                                         # Push back to main
+        git diff --staged --quiet || git commit -m "chore: Build dist files [skip ci]"  # Only commit if changes exist, add [skip ci]
+        git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
         id: semantic # Add an ID to reference the output
         run: npx semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_PAT }} # Changed from GITHUB_TOKEN
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # Add steps to update major version tag
@@ -57,21 +57,30 @@ jobs:
           MAJOR_VERSION=$(echo $RELEASE_VERSION | sed -E 's/v([0-9]+)\..*/\1/')
           MAJOR_TAG="v$MAJOR_VERSION"
           echo "Updating tag $MAJOR_TAG to point to $RELEASE_VERSION"
+          # Configure git user for this push
+          git config --global user.name "semantic-release-bot"
+          git config --global user.email "semantic-release-bot@users.noreply.github.com"
           # Create or update the major version tag locally, pointing to the same commit as the release version tag
           git tag -f $MAJOR_TAG $RELEASE_VERSION 
           # Force push the major version tag to the remote
-          git push --force origin $MAJOR_TAG
+          git push --force https://x-access-token:${{ secrets.SEMANTIC_RELEASE_PAT }}@github.com/${{ github.repository }} $MAJOR_TAG
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN is not directly used by git push here, explicit token in URL
+          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+
 
       - name: Update latest tag
         # Only run if a new version was released (RELEASE_VERSION is set)
         if: env.RELEASE_VERSION 
         run: |
           echo "Updating latest tag to point to $RELEASE_VERSION"
+          # Configure git user for this push (if not already done globally in job)
+          git config --global user.name "semantic-release-bot"
+          git config --global user.email "semantic-release-bot@users.noreply.github.com"
           # Create or update the latest tag locally, pointing it to the same commit as the release version tag
           git tag -f latest $RELEASE_VERSION 
           # Force push the latest tag to the remote
-          git push --force origin latest
+          git push --force https://x-access-token:${{ secrets.SEMANTIC_RELEASE_PAT }}@github.com/${{ github.repository }} latest
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN is not directly used by git push here, explicit token in URL
+          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Build Project
         run: npm run build
 
+      - name: Run tests
+        run: npm test
+
       - name: Run Semantic Release
         id: semantic # Add an ID to reference the output
         run: npx semantic-release

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Build Project
         run: npm run build
 
+      - name: Run tests
+        run: npm test
+
       - name: Read current version from package.json
         id: package_version
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ The project follows a structured process from development to production, using a
    - Merging to `main` will automatically trigger:
      1. The `build-and-commit.yml` workflow (ensures `dist/` is current)
      2. The `release.yml` workflow (handles versioning and publishing)
-   - `semantic-release` will then:
+     3. `semantic-release` will then:
      - Analyze the commits on `main` since the last release tag (using rules from `.releaserc.json`).
      - Determine the appropriate next version number based on conventional commits.
      - Generate release notes automatically from commit messages.


### PR DESCRIPTION
This pull request introduces updates to GitHub Actions workflows to streamline CI/CD processes and improve automation. Key changes include adding pull request support to workflows, ensuring tests are run consistently, and enhancing token usage for secure operations. Additionally, minor documentation updates clarify workflow behavior.

### Workflow Enhancements:

* [`.github/workflows/build-and-commit.yml`](diffhunk://#diff-f6388d17ad9d1ffad649264dff553a00597a9c1a716ebeaed61d2b873ad22cc1R8-R11): Added support for `pull_request` events to trigger the workflow on `main` and `develop` branches. Updated the `Commit built files` step to only run on `push` events and include `[skip ci]` in commit messages to prevent redundant CI runs. [[1]](diffhunk://#diff-f6388d17ad9d1ffad649264dff553a00597a9c1a716ebeaed61d2b873ad22cc1R8-R11) [[2]](diffhunk://#diff-f6388d17ad9d1ffad649264dff553a00597a9c1a716ebeaed61d2b873ad22cc1R33-R46)
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R38-R45): Replaced `GITHUB_TOKEN` with `SEMANTIC_RELEASE_PAT` for secure authentication during semantic release and tag updates. Configured the git user globally for consistent tagging and pushing operations. Explicitly included the token in the remote URL for `git push` commands. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R38-R45) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R63-R89)
* [`.github/workflows/test-publish.yml`](diffhunk://#diff-3cedd3e25b37e98fa5e369ba7225abf722e43eb8a2e527db6186c899ab833614R36-R38): Added a step to run tests before reading the current version from `package.json`.

### Documentation Update:

* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L157-R157): Clarified the sequence of workflows triggered by merging to `main`, explicitly listing `semantic-release` as the third step.