### PR TITLE
fix(ci): Update release workflow to trigger on completion of Build an…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,19 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main # Trigger on pushes to the main branch
+  workflow_run:
+    workflows: ["Build and Commit"] # Name of the triggering workflow
+    types:
+      - completed
+    branches: # Filters for the branch the "Build and Commit" workflow ran on
+      - main
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Condition to ensure this job only runs if the triggering workflow ("Build and Commit")
+    # was itself triggered by a 'push' event to 'main' and completed successfully.
+    if: github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success'
     permissions:
       # Needs write access to create releases, read packages, and write for discussions (for notes)
       contents: 'write'
@@ -21,8 +27,9 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref: main # Explicitly check out the main branch
+          ref: main # Explicitly check out the latest main branch
           fetch-depth: 0 # Ensure full history is fetched
+          # token: ${{ secrets.SEMANTIC_RELEASE_PAT }} # Optional: use PAT if default GITHUB_TOKEN has issues with workflow_run checkout, but usually not needed for same repo.
 
       - name: Set up Node.js
         uses: actions/setup-node@v3
@@ -42,10 +49,9 @@ jobs:
         id: semantic # Add an ID to reference the output
         run: npx semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_PAT }} # Changed from GITHUB_TOKEN
+          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # Add steps to update major version tag
       - name: Get released version
         # Check if semantic-release step produced a new version
         if: steps.semantic.outputs.new_release_published == 'true' 
@@ -53,6 +59,7 @@ jobs:
           echo "RELEASE_VERSION=${{ steps.semantic.outputs.new_release_version }}" >> $GITHUB_ENV
           echo "New version released: ${{ steps.semantic.outputs.new_release_version }}"
 
+      # Add steps to update major version tag
       - name: Update Major Version Tag (e.g., v1)
         if: env.RELEASE_VERSION # Only run if a new version was released
         run: |

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -23,15 +23,7 @@
       }
     ],
     "@semantic-release/release-notes-generator",
-    "@semantic-release/changelog",
     "@semantic-release/npm",
-    "@semantic-release/github",
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["package.json", "CHANGELOG.md", "dist"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ]
+    "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
This pull request updates the release workflow to improve its triggering mechanism, streamline configuration, and simplify the `.releaserc.json` file. The most important changes include replacing the `push` event trigger with a `workflow_run` trigger, refining job conditions and permissions, and removing redundant plugins from the release configuration.

### Workflow trigger updates:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L4-R16): Changed the trigger from `push` to `workflow_run`, making the release workflow dependent on the completion of the "Build and Commit" workflow on the `main` branch. Added a condition to ensure the release workflow runs only when the triggering workflow was initiated by a `push` event and completed successfully.

### Job refinements:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L24-R32): Updated the checkout step to clarify that the latest `main` branch is checked out. Added a comment about using a personal access token (`PAT`) for potential issues with `workflow_run` checkout.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L45-R62): Adjusted the semantic-release step to ensure the `GITHUB_TOKEN` and `NPM_TOKEN` are properly set and added steps to update the major version tag only if a new release version is published.

### Configuration simplification:
* [`.releaserc.json`](diffhunk://#diff-e774e90e159e39c0a392fffa584ea8520508a9a0c10468d0bd685800e28a42f5L26-R27): Removed the `@semantic-release/changelog` and `@semantic-release/git` plugins, simplifying the release configuration by retaining only the necessary plugins for GitHub and npm integration.…d Commit workflow