### PR TITLE
fix(ci): Update release workflow to check for new version output and …

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,11 +53,20 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Get released version
-        # Check if semantic-release step produced a new version
-        if: steps.semantic.outputs.new_release_published == 'true' 
+        # Check if semantic-release step produced a new version by checking the version output
+        if: steps.semantic.outputs.new_release_version != '' && steps.semantic.outputs.new_release_version != null
         run: |
           echo "RELEASE_VERSION=${{ steps.semantic.outputs.new_release_version }}" >> $GITHUB_ENV
           echo "New version released: ${{ steps.semantic.outputs.new_release_version }}"
+
+      # Add a step to debug outputs if the problem persists
+      - name: Dump semantic-release outputs
+        if: always() # Always run this step to see the outputs
+        run: |
+          echo "Semantic Release Outputs:"
+          echo "new_release_published: ${{ steps.semantic.outputs.new_release_published }}"
+          echo "new_release_version: ${{ steps.semantic.outputs.new_release_version }}"
+          echo "new_release_notes: ${{ steps.semantic.outputs.new_release_notes }}"
 
       # Add steps to update major version tag
       - name: Update Major Version Tag (e.g., v1)


### PR DESCRIPTION
This pull request updates the `.github/workflows/release.yml` file to improve the handling and debugging of semantic-release outputs. The changes ensure better reliability in detecting new releases and provide additional debugging information when issues occur.

Enhancements to semantic-release workflow:

* Updated the condition for checking if a new release was published to use `steps.semantic.outputs.new_release_version` instead of `steps.semantic.outputs.new_release_published`. This ensures the condition checks for both non-empty and non-null values for the version output.
* Added a new step to dump all semantic-release outputs for debugging purposes. This step runs unconditionally to provide visibility into the outputs, aiding in troubleshooting.…add debugging step