### PR TITLE
fix(ci): use programmatic semantic-release for reliable JSON output

### DIFF
--- a/.github/workflows/const semanticRelease = require('semanti.js
+++ b/.github/workflows/const semanticRelease = require('semanti.js
@@ -1,0 +1,29 @@
+const semanticRelease = require('semantic-release');
+
+async function main() {
+  try {
+    // Pass default options; semantic-release will use configuration from .releaserc.json or package.json
+    // Ensure GITHUB_TOKEN and NPM_TOKEN are available in the environment for semantic-release to use.
+    const result = await semanticRelease({
+      // Explicitly pass branch and repositoryUrl if needed, though usually auto-detected.
+      // branches: process.env.GITHUB_REF_NAME, // or specific branch like 'main'
+      // repositoryUrl: `https://github.com/${process.env.GITHUB_REPOSITORY}.git`,
+    });
+
+    if (result) {
+      // A release was published, print the JSON result to stdout
+      // This includes objects like 'lastRelease', 'commits', 'nextRelease', 'releases'.
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      // No release was published. stdout will be empty.
+      // Log to stderr so it doesn't interfere with output file if this script's stdout is captured.
+      console.error('No release published by semantic-release (programmatic run).');
+    }
+  } catch (error) {
+    // An error occurred during semantic-release execution.
+    console.error('Semantic Release programmatic run failed:', error);
+    process.exitCode = 1; // Indicate failure; the shell command's `|| true` in the workflow will handle this.
+  }
+}
+
+main();

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,12 @@ jobs:
       - name: Run Semantic Release
         id: semantic
         run: |
-          npx semantic-release -q > semantic-release-output.json || true 
-          # '-q' (quiet) should suppress logs, leaving only JSON in stdout.
-          # '|| true' ensures the step doesn't fail if semantic-release exits with a non-zero code when no release is made.
+          node .github/scripts/run-semantic-release.js > semantic-release-output.json 2> semantic-release-error.log || true
+          # If run-semantic-release.js encounters an error or no release, 
+          # semantic-release-output.json might be empty or not created.
+          # Errors from the script go to semantic-release-error.log.
+          # '|| true' ensures this step doesn't fail the workflow if semantic-release itself (programmatically) exits with an error
+          # or if no release is made (script exits cleanly, output file is empty).
         env:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_PAT }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -58,16 +61,23 @@ jobs:
       - name: Set Semantic Release Outputs
         id: sr_outputs
         run: |
-          echo "--- Debug: Initial content of semantic-release-output.json (after 'semantic-release -q') ---"
+          echo "--- Debug: Content of semantic-release-output.json (after programmatic run) ---"
           if [ -f semantic-release-output.json ]; then
             cat semantic-release-output.json
           else
-            echo "semantic-release-output.json does NOT exist at the start of the step."
+            echo "semantic-release-output.json does NOT exist."
           fi
-          echo "--- End of initial content ---"
+          echo "--- End of content ---"
+
+          echo "--- Debug: Content of semantic-release-error.log ---"
+          if [ -f semantic-release-error.log ]; then
+            cat semantic-release-error.log
+          else
+            echo "semantic-release-error.log does NOT exist."
+          fi
+          echo "--- End of error log content ---"
 
           if [ -f semantic-release-output.json ] && [ -s semantic-release-output.json ]; then
-            # With '-q', the file should ideally contain only JSON or be empty.
             JSON_OUTPUT=$(cat semantic-release-output.json)
 
             if echo "$JSON_OUTPUT" | jq -e . > /dev/null; then
@@ -83,9 +93,12 @@ jobs:
                 echo "new_release_published=true" >> $GITHUB_OUTPUT
                 echo "new_release_version=$VERSION" >> $GITHUB_OUTPUT
                 
-                echo "new_release_notes<<EOF_NOTES" >> $GITHUB_OUTPUT
-                echo "$NOTES_RAW" >> $GITHUB_OUTPUT
-                echo "EOF_NOTES" >> $GITHUB_OUTPUT
+                # Ensure notes are properly escaped for multiline output
+                {
+                  echo "new_release_notes<<EOF_NOTES"
+                  echo "$NOTES_RAW"
+                  echo "EOF_NOTES"
+                } >> $GITHUB_OUTPUT
 
                 echo "Successfully parsed release information: Version $VERSION"
               else
@@ -95,15 +108,15 @@ jobs:
                 echo "new_release_notes=" >> $GITHUB_OUTPUT
               fi
             else
-              echo "Failed to validate semantic-release-output.json as JSON."
+              echo "Failed to validate semantic-release-output.json as JSON (programmatic run)."
               echo "File content was:"
-              echo "$JSON_OUTPUT" # This will be the same as cat semantic-release-output.json
+              cat semantic-release-output.json
               echo "new_release_published=false" >> $GITHUB_OUTPUT
               echo "new_release_version=" >> $GITHUB_OUTPUT
               echo "new_release_notes=" >> $GITHUB_OUTPUT
             fi
           else
-            echo "semantic-release-output.json does not exist or is empty (no release made or -q suppressed all output)."
+            echo "semantic-release-output.json does not exist or is empty (no release made or programmatic run failed to produce JSON output)."
             echo "new_release_published=false" >> $GITHUB_OUTPUT
             echo "new_release_version=" >> $GITHUB_OUTPUT
             echo "new_release_notes=" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This commit introduces a Node.js script to run semantic-release programmatically. This approach aims to provide a more reliable way to capture the JSON output from semantic-release, as direct CLI output redirection (even with -q) was inconsistently including log data, causing parsing failures.

Changes include:
- Added `.github/scripts/run-semantic-release.js` to invoke semantic-release via its API and print JSON results to stdout.
- Updated the `Run Semantic Release` step in `release.yml` to execute this script, redirecting its stdout to `semantic-release-output.json` and stderr to `semantic-release-error.log`.
- Enhanced debugging in the `Set Semantic Release Outputs` step to show contents of both output and error log files.

This change is intended to resolve persistent issues with contaminated output files and ensure the release workflow can reliably extract release details.