### PR TITLE
ci(release): run release workflows on node 22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,9 +40,9 @@ jobs:
           # token: ${{ secrets.SEMANTIC_RELEASE_PAT }} # Optional: use PAT if default GITHUB_TOKEN has issues with workflow_run checkout, but usually not needed for same repo.
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22.14.0'
 
       - name: Install Dependencies
         run: npm ci

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -21,9 +21,9 @@ jobs:
           fetch-depth: 0  # Important for access to all history and tags
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22.14.0'
           registry-url: 'https://registry.npmjs.org/'
           scope: '@gtrevorrow'
 

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -16,7 +16,7 @@ jobs:
       packages: 'write'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Important for access to all history and tags
 


### PR DESCRIPTION
## Summary

- Updates the Release workflow from `actions/setup-node@v3` / Node 20 to `actions/setup-node@v4` / Node 22.14.0.
- Updates the Test Package Publishing workflow to the same Node runtime.

## Why

This prepares `main` before merging `develop`, where the release toolchain has moved to semantic-release 25. That version requires Node `^22.14.0` or `>=24.10.0`, so this keeps the production release workflow compatible before the upcoming major release merge.

## Validation

- Diff is limited to `.github/workflows/release.yml` and `.github/workflows/test-publish.yml`.
- Commit type is `ci`, which is configured as non-releasing in `.releaserc.json`.