### PR TITLE
ci(release): print semantic-release logs on failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,10 @@ jobs:
         id: semantic
         run: |
           set -o pipefail # Ensure pipeline fails if node script fails before output redirection
+          set +e # Capture semantic-release's exit code so logs can be printed before failing
           node .github/scripts/run-semantic-release.js > semantic-release-output.json 2> semantic-release-error.log
           SCRIPT_EXIT_CODE=$?
+          set -e
           echo "Semantic release script exited with code: $SCRIPT_EXIT_CODE"
           
           # Always output error log content for debugging


### PR DESCRIPTION
## Summary

- Captures the semantic-release script exit code even when it fails.
- Prints `semantic-release-error.log` and `semantic-release-output.json` before intentionally failing the workflow on exit code 1.

## Why

The latest release workflow run reached Node 22.14.0, built successfully, and passed tests, but the semantic-release failure happened before the workflow printed the captured error log because the shell was running with `-e`. This change preserves the intended failure behavior while making the underlying semantic-release error visible.

## Validation

- Diff is limited to `.github/workflows/release.yml`.
- Commit type is `ci`, which is configured as non-releasing in `.releaserc.json`.