### PR TITLE
feat: use published npm CLI and Node.js 24

### DIFF
--- a/.github/workflows/build-and-commit.yml
+++ b/.github/workflows/build-and-commit.yml
@@ -17,12 +17,12 @@ jobs:
       contents: write # Add this line to grant write permissions
     steps:
       # 1. Checks out your repository code
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # 2. Sets up Node.js environment
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "22.14.0"
+          node-version: "24"
 
       # 3. Installs dependencies (including @vercel/ncc for bundling)
       - run: npm ci

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -21,12 +21,12 @@ jobs:
       id-token: "write"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4.0.3
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install OCI CLI
         run: |
@@ -67,4 +67,3 @@ jobs:
         shell: bash
         run: |
           oci --auth security_token --profile GORDON --config-file ${{ github.workspace }}/.oci/config os ns get
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,16 +33,16 @@ jobs:
       issues: 'write'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main # Explicitly check out the latest main branch
           fetch-depth: 0 # Ensure full history is fetched
           # token: ${{ secrets.SEMANTIC_RELEASE_PAT }} # Optional: use PAT if default GITHUB_TOKEN has issues with workflow_run checkout, but usually not needed for same repo.
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '22.14.0'
+          node-version: '>=24.10.0 <25'
 
       - name: Install Dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,21 @@ jobs:
           echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
           echo "New version released: $VERSION"
 
+      - name: Update npm major release dist-tag (e.g., major-v1)
+        if: env.RELEASE_VERSION
+        run: |
+          VERSION="${RELEASE_VERSION#v}"
+          MAJOR_VERSION=$(echo "$VERSION" | sed -E 's/([0-9]+)\..*/\1/')
+          NPM_MAJOR_TAG="major-v$MAJOR_VERSION"
+          PACKAGE_NAME=$(node -p 'require("./package.json").name')
+
+          echo "Updating npm dist-tag $NPM_MAJOR_TAG to $PACKAGE_NAME@$VERSION"
+          npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
+          npm dist-tag add "$PACKAGE_NAME@$VERSION" "$NPM_MAJOR_TAG"
+        env:
+          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       # Add a step to debug outputs if the problem persists
       - name: Dump semantic-release outputs
         if: always()

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup OCI CLI Profile via Token Exchange
         # This uses the local action in the current repository.
@@ -28,7 +28,7 @@ jobs:
           # oci_home: '/home/runner/.oci_tf' # Optional: specify a custom OCI home
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: latest # Or specify a fixed version
 

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -16,14 +16,14 @@ jobs:
       packages: 'write'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Important for access to all history and tags
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '22.14.0'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org/'
           scope: '@gtrevorrow'
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: node:20
+image: node:24
 
 variables:
   # CI does not need local git hooks.
@@ -17,7 +17,7 @@ deploy:
     # Install OCI CLI
     - *oci_setup
 
-    # Docker runners get Node from image: node:20.
+    # Docker runners get Node from image: node:24.
     # Shell runners must already provide node and npm on the host.
     # This example models a consuming GitLab project, not this repository.
     # Pin the published CLI release used by this example.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,8 +20,8 @@ deploy:
     # Docker runners get Node from image: node:20.
     # Shell runners must already provide node and npm on the host.
     # This example models a consuming GitLab project, not this repository.
-    # It assumes a beta version has already been published to npm.
-    - npm install --no-save @gtrevorrow/oci-token-exchange@beta
+    # Pin the published CLI release used by this example.
+    - npm install --no-save @gtrevorrow/oci-token-exchange@1.2.2
 
     # Map the requested GitLab ID token to the variable the CLI expects
     - export CI_JOB_JWT_V2="$ID_TOKEN"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ npm install -g @gtrevorrow/oci-token-exchange
 npm install -g @gtrevorrow/oci-token-exchange@<release-tag>
 ```
 
+Stable releases are published with `latest` and a major-family npm dist-tag such
+as `major-v1`. The major-family tag advances to the newest stable point release
+for that major version. npm does not permit `v1` or `v2` as dist-tags because
+they can be interpreted as semantic-version ranges.
+
 ## Usage
 
 ### Inputs and Outputs

--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ Pinning guidance:
 ```bash
 npm install -g @gtrevorrow/oci-token-exchange
 
-# Install a specific version globally (e.g., 1.2.3)
-npm install -g @gtrevorrow/oci-token-exchange@1.2.3
+# Install a specific release globally
+npm install -g @gtrevorrow/oci-token-exchange@1.2.2
 
-# Install a version with a specific tag (e.g., beta)
-npm install -g @gtrevorrow/oci-token-exchange@beta
+# Install the release used by the CI examples below
+npm install -g @gtrevorrow/oci-token-exchange@1.2.2
 ```
 
 ## Usage
@@ -165,9 +165,9 @@ Use the example below together with the [Inputs and Outputs](#inputs-and-outputs
 
 ### GitLab CI
 
-This example mirrors [.gitlab-ci.yml](.gitlab-ci.yml). It installs the published
-beta package without modifying the consumer project's manifest, maps the GitLab
-ID token to `CI_JOB_JWT_V2`, and invokes the package's installed binary.
+This example mirrors [.gitlab-ci.yml](.gitlab-ci.yml). It installs the pinned
+published release (`1.2.2`) without modifying the consumer project's manifest,
+maps the GitLab ID token to `CI_JOB_JWT_V2`, and invokes the package's installed binary.
 
 ```yaml
 image: node:20
@@ -187,7 +187,7 @@ deploy:
   script:
     - *oci_setup
 
-    - npm install --no-save @gtrevorrow/oci-token-exchange@beta
+    - npm install --no-save @gtrevorrow/oci-token-exchange@1.2.2
 
     - export CI_JOB_JWT_V2="$ID_TOKEN"
 
@@ -215,8 +215,8 @@ deploy:
 ### Bitbucket Pipelines
 
 This example mirrors [bitbucket-pipelines.yml](bitbucket-pipelines.yml). The
-default pipeline uses the published beta package; the `main` branch uses the
-current published release. Both invoke the locally installed package with
+default and `main` pipelines both use the pinned published release (`1.2.2`).
+Both invoke the locally installed package with
 `npx --no-install` and explicitly verify the generated OCI configuration.
 
 ```yaml
@@ -231,7 +231,7 @@ pipelines:
           - curl -LO https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh
           - bash install.sh --accept-all-defaults
           - export PATH=$PATH:/root/bin
-          - npm install --no-save @gtrevorrow/oci-token-exchange@beta
+          - npm install --no-save @gtrevorrow/oci-token-exchange@1.2.2
           - |
             PLATFORM=bitbucket \
             OIDC_CLIENT_IDENTIFIER=${OIDC_CLIENT_IDENTIFIER} \
@@ -258,7 +258,7 @@ pipelines:
             - curl -LO https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh
             - bash install.sh --accept-all-defaults
             - export PATH=$PATH:/root/bin
-            - npm install --no-save @gtrevorrow/oci-token-exchange
+            - npm install --no-save @gtrevorrow/oci-token-exchange@1.2.2
             - |
               PLATFORM=bitbucket \
               OIDC_CLIENT_IDENTIFIER=${OIDC_CLIENT_IDENTIFIER} \

--- a/README.md
+++ b/README.md
@@ -59,11 +59,9 @@ Pinning guidance:
 ```bash
 npm install -g @gtrevorrow/oci-token-exchange
 
-# Install a specific release globally
-npm install -g @gtrevorrow/oci-token-exchange@1.2.2
-
-# Install the release used by the CI examples below
-npm install -g @gtrevorrow/oci-token-exchange@1.2.2
+# Install the published release tag you want to use.
+# Replace <release-tag> with your chosen release tag or version.
+npm install -g @gtrevorrow/oci-token-exchange@<release-tag>
 ```
 
 ## Usage
@@ -165,9 +163,10 @@ Use the example below together with the [Inputs and Outputs](#inputs-and-outputs
 
 ### GitLab CI
 
-This example mirrors [.gitlab-ci.yml](.gitlab-ci.yml). It installs the pinned
-published release (`1.2.2`) without modifying the consumer project's manifest,
-maps the GitLab ID token to `CI_JOB_JWT_V2`, and invokes the package's installed binary.
+This example follows the working setup in [.gitlab-ci.yml](.gitlab-ci.yml).
+Replace `<release-tag>` with the published release tag or version you want to
+use. The package is installed without modifying the consumer project's manifest,
+the GitLab ID token is mapped to `CI_JOB_JWT_V2`, and the installed binary runs with `npx --no-install`.
 
 ```yaml
 image: node:20
@@ -187,7 +186,7 @@ deploy:
   script:
     - *oci_setup
 
-    - npm install --no-save @gtrevorrow/oci-token-exchange@1.2.2
+    - npm install --no-save @gtrevorrow/oci-token-exchange@<release-tag>
 
     - export CI_JOB_JWT_V2="$ID_TOKEN"
 
@@ -214,10 +213,10 @@ deploy:
 
 ### Bitbucket Pipelines
 
-This example mirrors [bitbucket-pipelines.yml](bitbucket-pipelines.yml). The
-default and `main` pipelines both use the pinned published release (`1.2.2`).
-Both invoke the locally installed package with
-`npx --no-install` and explicitly verify the generated OCI configuration.
+This example follows the working setup in [bitbucket-pipelines.yml](bitbucket-pipelines.yml).
+Replace `<release-tag>` with the published release tag or version you want to
+use. Both pipelines invoke the locally installed package with `npx --no-install`
+and explicitly verify the generated OCI configuration.
 
 ```yaml
 image: node:20
@@ -231,7 +230,7 @@ pipelines:
           - curl -LO https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh
           - bash install.sh --accept-all-defaults
           - export PATH=$PATH:/root/bin
-          - npm install --no-save @gtrevorrow/oci-token-exchange@1.2.2
+          - npm install --no-save @gtrevorrow/oci-token-exchange@<release-tag>
           - |
             PLATFORM=bitbucket \
             OIDC_CLIENT_IDENTIFIER=${OIDC_CLIENT_IDENTIFIER} \
@@ -258,7 +257,7 @@ pipelines:
             - curl -LO https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh
             - bash install.sh --accept-all-defaults
             - export PATH=$PATH:/root/bin
-            - npm install --no-save @gtrevorrow/oci-token-exchange@1.2.2
+            - npm install --no-save @gtrevorrow/oci-token-exchange@<release-tag>
             - |
               PLATFORM=bitbucket \
               OIDC_CLIENT_IDENTIFIER=${OIDC_CLIENT_IDENTIFIER} \

--- a/README.md
+++ b/README.md
@@ -9,11 +9,7 @@
   - [Inputs And Outputs](#inputs-and-outputs)
   - [GitHub Actions](#github-actions)
   - [GitLab CI](#gitlab-ci)
-    - [Option 1: Building from Source](#option-1-building-from-source)
-    - [Option 2: Using npm Package](#option-2-using-npm-package)
   - [Bitbucket Pipelines](#bitbucket-pipelines)
-    - [Option 1: Building from Source](#option-1-building-from-source-1)
-    - [Option 2: Using npm Package](#option-2-using-npm-package-1)
   - [Standalone CLI Usage](#standalone-cli-usage)
   - [Debugging](#debugging)
 - [How it Works](#how-it-works)
@@ -169,40 +165,32 @@ Use the example below together with the [Inputs and Outputs](#inputs-and-outputs
 
 ### GitLab CI
 
-#### Option 1: Building from Source
-
-This example builds the CLI from the checked-out repository and then runs it.
-It is written to reflect typical GitLab Docker-runner usage. If you use a shell
-runner instead, the host must already provide `node`, `npm`, `python3`, and
-`python3 -m venv`.
-
-See [Inputs and Outputs](#inputs-and-outputs) for the full environment variable contract and required GitLab token mapping.
+This example mirrors [.gitlab-ci.yml](.gitlab-ci.yml). It installs the published
+beta package without modifying the consumer project's manifest, maps the GitLab
+ID token to `CI_JOB_JWT_V2`, and invokes the package's installed binary.
 
 ```yaml
 image: node:20
 
+variables:
+  HUSKY: "0"
+
 .oci_setup: &oci_setup |
+  # Docker runners should only need Python 3 + venv support in the job image.
+  # Shell runners must provide python3 and python3 -m venv on the host.
   python3 -m venv .oci-cli
   . .oci-cli/bin/activate
   python -m pip install --upgrade pip
   pip install oci-cli
-
-variables:
-  HUSKY: "0"
 
 deploy:
   script:
-    # Install OCI CLI
     - *oci_setup
-    
-    # Build the token exchange CLI from the checked-out commit
-    - npm ci
-    - npm run build:cli
-    
-    # Map the GitLab ID token to the variable the CLI expects
+
+    - npm install --no-save @gtrevorrow/oci-token-exchange@beta
+
     - export CI_JOB_JWT_V2="$ID_TOKEN"
-    
-    # Run the built CLI
+
     - |
       PLATFORM=gitlab \
       OIDC_CLIENT_IDENTIFIER=${OIDC_CLIENT_IDENTIFIER} \
@@ -210,122 +198,26 @@ deploy:
       OCI_TENANCY=${OCI_TENANCY} \
       OCI_REGION=${OCI_REGION} \
       OCI_HOME=${CI_PROJECT_DIR} \
-      OCI_PROFILE=${OCI_PROFILE:-DEFAULT} \
+      OCI_PROFILE=${OCI_PROFILE} \
       RETRY_COUNT=${RETRY_COUNT:-3} \
-      node dist/cli.js
-    
-    # Verify OCI CLI configuration works
+      npx --no-install oci-token-exchange
+
     - oci --auth security_token --config-file "$CI_PROJECT_DIR/.oci/config" --profile "${OCI_PROFILE:-DEFAULT}" os ns get
-  
+
   rules:
-    - if: $CI_COMMIT_BRANCH == "main"
-  
+    - if: $CI_COMMIT_BRANCH == "develop"
+
   id_tokens:
     ID_TOKEN:
-      aud: https://cloud.oracle.com/gitlab
-```
-
-#### Option 2: Using npm Package
-
-This example installs the CLI tool directly from npm.
-
-```yaml
-image: node:20
-
-.oci_setup: &oci_setup |
-  python3 -m venv .oci-cli
-  . .oci-cli/bin/activate
-  python -m pip install --upgrade pip
-  pip install oci-cli
-
-variables:
-  HUSKY: "0"
-
-deploy_npm:
-  script:
-    # Install OCI CLI
-    - *oci_setup
-    
-    # Install the token exchange CLI from npm
-    - npm install -g @gtrevorrow/oci-token-exchange
-    
-    # Map the GitLab ID token to the variable the CLI expects
-    - export CI_JOB_JWT_V2="$ID_TOKEN"
-    
-    # Run the installed CLI
-    - |
-      PLATFORM=gitlab \
-      OIDC_CLIENT_IDENTIFIER=${OIDC_CLIENT_IDENTIFIER} \
-      DOMAIN_BASE_URL=${DOMAIN_BASE_URL} \
-      OCI_TENANCY=${OCI_TENANCY} \
-      OCI_REGION=${OCI_REGION} \
-      OCI_HOME=${CI_PROJECT_DIR} \
-      OCI_PROFILE=${OCI_PROFILE:-DEFAULT} \
-      RETRY_COUNT=${RETRY_COUNT:-3} \
-      oci-token-exchange
-    
-    # Verify OCI CLI configuration works
-    - oci --auth security_token --config-file "$CI_PROJECT_DIR/.oci/config" --profile "${OCI_PROFILE:-DEFAULT}" os ns get
-  
-  rules:
-    - if: $CI_COMMIT_BRANCH == "main"
-  
-  id_tokens:
-    ID_TOKEN:
-      aud: https://cloud.oracle.com/gitlab
+      aud: https://cloud.oracle.com/
 ```
 
 ### Bitbucket Pipelines
 
-#### Option 1: Building from Source
-
-This example clones the repository, builds the CLI, and then runs it.
-
-See [Inputs and Outputs](#inputs-and-outputs) for the full environment variable contract and Bitbucket OIDC token requirement.
-
-```yaml
-image: node:20
-
-pipelines:
-  default:
-    - step:
-        name: Setup OCI CLI with OIDC Token Exchange (Build from Source)
-        oidc: true  # Enable OIDC for Bitbucket
-        script:
-          # Setup OCI CLI
-          - curl -LO https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh
-          - bash install.sh --accept-all-defaults
-          - export PATH=$PATH:/root/bin
-          
-          # Clone and build the token exchange CLI from GitHub
-          - git clone https://github.com/gtrevorrow/oci-token-exchange-action.git
-          - cd oci-token-exchange-action
-          - npm ci
-          - npm run build:cli
-          
-          # Run the built CLI for token exchange
-          - >
-            cd dist &&
-            export PLATFORM=bitbucket &&
-            export OIDC_CLIENT_IDENTIFIER=${OIDC_CLIENT_IDENTIFIER} &&
-            export DOMAIN_BASE_URL=${DOMAIN_BASE_URL} &&
-            export OCI_TENANCY=${OCI_TENANCY} &&
-            export OCI_REGION=${OCI_REGION} &&
-            export RETRY_COUNT=3
-          - node cli.js || exit 1
-          
-          # Verify OCI CLI works with generated token
-          - cd ../..
-          - oci os ns get
-        
-        # Preserve credentials for subsequent steps
-        artifacts:
-          - ".oci/**"
-```
-
-#### Option 2: Using npm Package
-
-This example installs the CLI tool directly from npm.
+This example mirrors [bitbucket-pipelines.yml](bitbucket-pipelines.yml). The
+default pipeline uses the published beta package; the `main` branch uses the
+current published release. Both invoke the locally installed package with
+`npx --no-install` and explicitly verify the generated OCI configuration.
 
 ```yaml
 image: node:20
@@ -333,33 +225,56 @@ image: node:20
 pipelines:
   default:
     - step:
-        name: Setup OCI CLI with OIDC Token Exchange (npm Package)
-        oidc: true  # Enable OIDC for Bitbucket
+        name: Setup OCI CLI with OIDC Token Exchange
+        oidc: true
         script:
-          # Setup OCI CLI
           - curl -LO https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh
           - bash install.sh --accept-all-defaults
           - export PATH=$PATH:/root/bin
-          
-          # Install the token exchange CLI from npm
-          - npm install -g @gtrevorrow/oci-token-exchange
-          
-          # Run the installed CLI for token exchange
-          - >
-            export PLATFORM=bitbucket &&
-            export OIDC_CLIENT_IDENTIFIER=${OIDC_CLIENT_IDENTIFIER} &&
-            export DOMAIN_BASE_URL=${DOMAIN_BASE_URL} &&
-            export OCI_TENANCY=${OCI_TENANCY} &&
-            export OCI_REGION=${OCI_REGION} &&
-            export RETRY_COUNT=3
-          - oci-token-exchange || exit 1
-          
-          # Verify OCI CLI works with generated token
-          - oci os ns get
-        
-        # Preserve credentials for subsequent steps
+          - npm install --no-save @gtrevorrow/oci-token-exchange@beta
+          - |
+            PLATFORM=bitbucket \
+            OIDC_CLIENT_IDENTIFIER=${OIDC_CLIENT_IDENTIFIER} \
+            DOMAIN_BASE_URL=${DOMAIN_BASE_URL} \
+            OCI_TENANCY=${OCI_TENANCY} \
+            OCI_REGION=${OCI_REGION} \
+            OCI_HOME=${BITBUCKET_CLONE_DIR} \
+            OCI_PROFILE=${OCI_PROFILE} \
+            RETRY_COUNT=${RETRY_COUNT:-3} \
+            npx --no-install oci-token-exchange
+          - oci --auth security_token --config-file "$BITBUCKET_CLONE_DIR/.oci/config" --profile "${OCI_PROFILE:-DEFAULT}" os ns get
         artifacts:
           - ".oci/**"
+          - "private_key.pem"
+          - "public_key.pem"
+          - "session"
+
+  branches:
+    main:
+      - step:
+          name: Setup OCI CLI with Published Package (Production)
+          oidc: true
+          script:
+            - curl -LO https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh
+            - bash install.sh --accept-all-defaults
+            - export PATH=$PATH:/root/bin
+            - npm install --no-save @gtrevorrow/oci-token-exchange
+            - |
+              PLATFORM=bitbucket \
+              OIDC_CLIENT_IDENTIFIER=${OIDC_CLIENT_IDENTIFIER} \
+              DOMAIN_BASE_URL=${DOMAIN_BASE_URL} \
+              OCI_TENANCY=${OCI_TENANCY} \
+              OCI_REGION=${OCI_REGION} \
+              OCI_HOME=${BITBUCKET_CLONE_DIR} \
+              OCI_PROFILE=${OCI_PROFILE} \
+              RETRY_COUNT=${RETRY_COUNT:-3} \
+              npx --no-install oci-token-exchange
+            - oci --auth security_token --config-file "$BITBUCKET_CLONE_DIR/.oci/config" --profile "${OCI_PROFILE:-DEFAULT}" os ns get
+          artifacts:
+            - ".oci/**"
+            - "private_key.pem"
+            - "public_key.pem"
+            - "session"
 ```
 
 ### Standalone CLI Usage

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ use. The package is installed without modifying the consumer project's manifest,
 the GitLab ID token is mapped to `CI_JOB_JWT_V2`, and the installed binary runs with `npx --no-install`.
 
 ```yaml
-image: node:20
+image: node:24
 
 variables:
   HUSKY: "0"
@@ -223,7 +223,7 @@ use. Both pipelines invoke the locally installed package with `npx --no-install`
 and explicitly verify the generated OCI configuration.
 
 ```yaml
-image: node:20
+image: node:24
 
 pipelines:
   default:

--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ npm install -g @gtrevorrow/oci-token-exchange@<release-tag>
 
 Stable releases are published with `latest` and a major-family npm dist-tag such
 as `major-v1`. The major-family tag advances to the newest stable point release
-for that major version. npm does not permit `v1` or `v2` as dist-tags because
-they can be interpreted as semantic-version ranges.
+for that major version.
 
 ## Usage
 

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ outputs:
     description: "The path to the generated private key used for the session."
 
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/action/index.js"
 
 branding:

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -20,8 +20,8 @@ pipelines:
           - bash install.sh --accept-all-defaults
           - export PATH=$PATH:/root/bin
           
-          # Install the published beta CLI used by the develop pipeline.
-          - npm install --no-save @gtrevorrow/oci-token-exchange@beta
+          # Install the pinned published CLI release used by this pipeline.
+          - npm install --no-save @gtrevorrow/oci-token-exchange@1.2.2
           
           # Run the CLI with proper environment variables
           - |
@@ -54,8 +54,8 @@ pipelines:
             - bash install.sh --accept-all-defaults
             - export PATH=$PATH:/root/bin
             
-            # Install the current published CLI release.
-            - npm install --no-save @gtrevorrow/oci-token-exchange
+            # Install the pinned published CLI release.
+            - npm install --no-save @gtrevorrow/oci-token-exchange@1.2.2
             
             # Run the CLI
             - |

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,4 +1,4 @@
-image: node:20
+image: node:24
 
 definitions:
   steps:

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -20,30 +20,23 @@ pipelines:
           - bash install.sh --accept-all-defaults
           - export PATH=$PATH:/root/bin
           
-          # Clone the develop branch and build the token exchange CLI
-          - git clone -b develop https://github.com/gtrevorrow/oci-token-exchange-action.git || git clone https://github.com/gtrevorrow/oci-token-exchange-action.git
-          - cd oci-token-exchange-action
-          - npm ci                    # ✅ Install dependencies fresh
-          - npm run build:cli        # ✅ Build the bundled CLI
-          - chmod +x dist/cli.js
+          # Install the published beta CLI used by the develop pipeline.
+          - npm install --no-save @gtrevorrow/oci-token-exchange@beta
           
           # Run the CLI with proper environment variables
           - |
-            cd dist && \
-            export DEBUG=true && \
-            export PLATFORM=bitbucket && \
-            export OIDC_CLIENT_IDENTIFIER=${OIDC_CLIENT_IDENTIFIER} && \
-            export DOMAIN_BASE_URL=${DOMAIN_BASE_URL} && \
-            export OCI_TENANCY=${OCI_TENANCY} && \
-            export OCI_REGION=${OCI_REGION} && \
-            export OCI_HOME=${BITBUCKET_CLONE_DIR} && \
-            export OCI_PROFILE=${OCI_PROFILE} && \
-            export RETRY_COUNT=${RETRY_COUNT:-3} && \
-            node cli.js || exit 1
+            PLATFORM=bitbucket \
+            OIDC_CLIENT_IDENTIFIER=${OIDC_CLIENT_IDENTIFIER} \
+            DOMAIN_BASE_URL=${DOMAIN_BASE_URL} \
+            OCI_TENANCY=${OCI_TENANCY} \
+            OCI_REGION=${OCI_REGION} \
+            OCI_HOME=${BITBUCKET_CLONE_DIR} \
+            OCI_PROFILE=${OCI_PROFILE} \
+            RETRY_COUNT=${RETRY_COUNT:-3} \
+            npx --no-install oci-token-exchange
           
           # Return to workspace root and verify OCI CLI works with generated token
-          - cd ../..
-          - oci --auth security_token os ns get
+          - oci --auth security_token --config-file "$BITBUCKET_CLONE_DIR/.oci/config" --profile "${OCI_PROFILE:-DEFAULT}" os ns get
         artifacts:
           - ".oci/**"
           - "private_key.pem"
@@ -53,7 +46,7 @@ pipelines:
   branches:
     main:
       - step:
-          name: Setup OCI CLI from GitHub Repository (Production)
+          name: Setup OCI CLI with Published Package (Production)
           oidc: true
           script:
             # Setup OCI CLI
@@ -61,32 +54,23 @@ pipelines:
             - bash install.sh --accept-all-defaults
             - export PATH=$PATH:/root/bin
             
-            # Clone main branch from GitHub and build CLI
-            - git clone --branch main https://github.com/gtrevorrow/oci-token-exchange-action.git
-            - cd oci-token-exchange-action
-            - npm ci
-            
-            # Build the CLI with explicit commands
-            - npm run build
-            - chmod +x dist/cli.js
+            # Install the current published CLI release.
+            - npm install --no-save @gtrevorrow/oci-token-exchange
             
             # Run the CLI
             - |
-              cd dist && \
-              export DEBUG=true && \
-              export PLATFORM=bitbucket && \
-              export OIDC_CLIENT_IDENTIFIER=${OIDC_CLIENT_IDENTIFIER} && \
-              export DOMAIN_BASE_URL=${DOMAIN_BASE_URL} && \
-              export OCI_TENANCY=${OCI_TENANCY} && \
-              export OCI_REGION=${OCI_REGION} && \
-              export OCI_HOME=${BITBUCKET_CLONE_DIR} && \
-              export OCI_PROFILE=${OCI_PROFILE} && \
-              export RETRY_COUNT=${RETRY_COUNT:-3} && \
-              node cli.js || exit 1
+              PLATFORM=bitbucket \
+              OIDC_CLIENT_IDENTIFIER=${OIDC_CLIENT_IDENTIFIER} \
+              DOMAIN_BASE_URL=${DOMAIN_BASE_URL} \
+              OCI_TENANCY=${OCI_TENANCY} \
+              OCI_REGION=${OCI_REGION} \
+              OCI_HOME=${BITBUCKET_CLONE_DIR} \
+              OCI_PROFILE=${OCI_PROFILE} \
+              RETRY_COUNT=${RETRY_COUNT:-3} \
+              npx --no-install oci-token-exchange
             
             # Return to workspace root and verify OCI CLI works
-            - cd ../..
-            - oci --auth security_token os ns get
+            - oci --auth security_token --config-file "$BITBUCKET_CLONE_DIR/.oci/config" --profile "${OCI_PROFILE:-DEFAULT}" os ns get
           artifacts:
             - ".oci/**"
             - "private_key.pem"

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
                 "@semantic-release/npm": "^13.1.5",
                 "@semantic-release/release-notes-generator": "^14.1.0",
                 "@types/jest": "^29.5.13",
-                "@types/node": "^20.17.11",
+                "@types/node": "^22.0.0",
                 "@typescript-eslint/eslint-plugin": "^8.1.0",
                 "@typescript-eslint/parser": "^8.1.0",
                 "@vercel/ncc": "^0.38.1",
@@ -52,7 +52,7 @@
                 "typescript-eslint": "^8.1.0"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22.14.0"
             }
         },
         "node_modules/@actions/core": {
@@ -2844,13 +2844,13 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "20.17.11",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.11.tgz",
-            "integrity": "sha512-Ept5glCK35R8yeyIeYlRIZtX6SLRyqMhOFTgj5SOkMpLTdw3SEHI9fHx60xaUZ+V1aJxQJODE+7/j5ocZydYTg==",
+            "version": "22.20.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+            "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~6.19.2"
+                "undici-types": "~6.21.0"
             }
         },
         "node_modules/@types/normalize-package-data": {
@@ -8428,11 +8428,590 @@
                 "node": ">=8"
             }
         },
+        "node_modules/npm/node_modules/@gar/promise-retry": {
+            "version": "1.0.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@isaacs/fs-minipass": {
+            "version": "4.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.4"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
+            "version": "1.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/@npmcli/agent": {
+            "version": "4.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.1",
+                "lru-cache": "^11.2.1",
+                "socks-proxy-agent": "^8.0.3"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/arborist": {
+            "version": "9.4.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@gar/promise-retry": "^1.0.0",
+                "@isaacs/string-locale-compare": "^1.1.0",
+                "@npmcli/fs": "^5.0.0",
+                "@npmcli/installed-package-contents": "^4.0.0",
+                "@npmcli/map-workspaces": "^5.0.0",
+                "@npmcli/metavuln-calculator": "^9.0.2",
+                "@npmcli/name-from-folder": "^4.0.0",
+                "@npmcli/node-gyp": "^5.0.0",
+                "@npmcli/package-json": "^7.0.0",
+                "@npmcli/query": "^5.0.0",
+                "@npmcli/redact": "^4.0.0",
+                "@npmcli/run-script": "^10.0.0",
+                "bin-links": "^6.0.0",
+                "cacache": "^20.0.1",
+                "common-ancestor-path": "^2.0.0",
+                "hosted-git-info": "^9.0.0",
+                "json-stringify-nice": "^1.1.4",
+                "lru-cache": "^11.2.1",
+                "minimatch": "^10.0.3",
+                "nopt": "^9.0.0",
+                "npm-install-checks": "^8.0.0",
+                "npm-package-arg": "^13.0.0",
+                "npm-pick-manifest": "^11.0.1",
+                "npm-registry-fetch": "^19.0.0",
+                "pacote": "^21.0.2",
+                "parse-conflict-json": "^5.0.1",
+                "proc-log": "^6.0.0",
+                "proggy": "^4.0.0",
+                "promise-all-reject-late": "^1.0.0",
+                "promise-call-limit": "^3.0.1",
+                "semver": "^7.3.7",
+                "ssri": "^13.0.0",
+                "treeverse": "^3.0.0",
+                "walk-up-path": "^4.0.0"
+            },
+            "bin": {
+                "arborist": "bin/index.js"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/config": {
+            "version": "10.8.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/map-workspaces": "^5.0.0",
+                "@npmcli/package-json": "^7.0.0",
+                "ci-info": "^4.0.0",
+                "ini": "^6.0.0",
+                "nopt": "^9.0.0",
+                "proc-log": "^6.0.0",
+                "semver": "^7.3.5",
+                "walk-up-path": "^4.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/fs": {
+            "version": "5.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/git": {
+            "version": "7.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@gar/promise-retry": "^1.0.0",
+                "@npmcli/promise-spawn": "^9.0.0",
+                "ini": "^6.0.0",
+                "lru-cache": "^11.2.1",
+                "npm-pick-manifest": "^11.0.1",
+                "proc-log": "^6.0.0",
+                "semver": "^7.3.5",
+                "which": "^6.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
+            "version": "4.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-bundled": "^5.0.0",
+                "npm-normalize-package-bin": "^5.0.0"
+            },
+            "bin": {
+                "installed-package-contents": "bin/index.js"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/map-workspaces": {
+            "version": "5.0.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/name-from-folder": "^4.0.0",
+                "@npmcli/package-json": "^7.0.0",
+                "glob": "^13.0.0",
+                "minimatch": "^10.0.3"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
+            "version": "9.0.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "cacache": "^20.0.0",
+                "json-parse-even-better-errors": "^5.0.0",
+                "pacote": "^21.0.0",
+                "proc-log": "^6.0.0",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/name-from-folder": {
+            "version": "4.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/node-gyp": {
+            "version": "5.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/package-json": {
+            "version": "7.0.5",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/git": "^7.0.0",
+                "glob": "^13.0.0",
+                "hosted-git-info": "^9.0.0",
+                "json-parse-even-better-errors": "^5.0.0",
+                "proc-log": "^6.0.0",
+                "semver": "^7.5.3",
+                "spdx-expression-parse": "^4.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/promise-spawn": {
+            "version": "9.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "which": "^6.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/query": {
+            "version": "5.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "postcss-selector-parser": "^7.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/redact": {
+            "version": "4.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@npmcli/run-script": {
+            "version": "10.0.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/node-gyp": "^5.0.0",
+                "@npmcli/package-json": "^7.0.0",
+                "@npmcli/promise-spawn": "^9.0.0",
+                "node-gyp": "^12.1.0",
+                "proc-log": "^6.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@sigstore/bundle": {
+            "version": "4.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@sigstore/protobuf-specs": "^0.5.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@sigstore/core": {
+            "version": "3.2.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
+            "version": "0.5.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.17.0 || >=20.5.0"
+            }
+        },
+        "node_modules/npm/node_modules/@sigstore/sign": {
+            "version": "4.1.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@gar/promise-retry": "^1.0.2",
+                "@sigstore/bundle": "^4.0.0",
+                "@sigstore/core": "^3.2.0",
+                "@sigstore/protobuf-specs": "^0.5.0",
+                "make-fetch-happen": "^15.0.4",
+                "proc-log": "^6.1.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@sigstore/tuf": {
+            "version": "4.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@sigstore/protobuf-specs": "^0.5.0",
+                "tuf-js": "^4.1.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@sigstore/verify": {
+            "version": "3.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@sigstore/bundle": "^4.0.0",
+                "@sigstore/core": "^3.1.0",
+                "@sigstore/protobuf-specs": "^0.5.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/@tufjs/canonical-json": {
+            "version": "2.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^16.14.0 || >=18.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/@tufjs/models": {
+            "version": "4.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tufjs/canonical-json": "2.0.0",
+                "minimatch": "^10.1.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/abbrev": {
+            "version": "4.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/agent-base": {
+            "version": "7.1.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/npm/node_modules/aproba": {
+            "version": "2.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC"
+        },
         "node_modules/npm/node_modules/archy": {
             "version": "1.0.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
+        },
+        "node_modules/npm/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/npm/node_modules/bin-links": {
+            "version": "6.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "cmd-shim": "^8.0.0",
+                "npm-normalize-package-bin": "^5.0.0",
+                "proc-log": "^6.0.0",
+                "read-cmd-shim": "^6.0.0",
+                "write-file-atomic": "^7.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/binary-extensions": {
+            "version": "3.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/npm/node_modules/brace-expansion": {
+            "version": "5.0.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/npm/node_modules/cacache": {
+            "version": "20.0.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/fs": "^5.0.0",
+                "fs-minipass": "^3.0.0",
+                "glob": "^13.0.0",
+                "lru-cache": "^11.1.0",
+                "minipass": "^7.0.3",
+                "minipass-collect": "^2.0.1",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "p-map": "^7.0.2",
+                "ssri": "^13.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/chalk": {
+            "version": "5.6.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/npm/node_modules/chownr": {
+            "version": "3.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/npm/node_modules/ci-info": {
+            "version": "4.4.0",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/cidr-regex": {
+            "version": "5.0.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/npm/node_modules/cmd-shim": {
+            "version": "8.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/common-ancestor-path": {
+            "version": "2.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/npm/node_modules/cssesc": {
+            "version": "3.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "bin": {
+                "cssesc": "bin/cssesc"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/debug": {
+            "version": "4.4.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/npm/node_modules/diff": {
+            "version": "8.0.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/npm/node_modules/env-paths": {
+            "version": "2.2.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/npm/node_modules/exponential-backoff": {
+            "version": "3.1.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0"
         },
         "node_modules/npm/node_modules/fastest-levenshtein": {
             "version": "1.0.16",
@@ -8443,12 +9022,969 @@
                 "node": ">= 4.9.1"
             }
         },
+        "node_modules/npm/node_modules/fs-minipass": {
+            "version": "3.0.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.3"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/glob": {
+            "version": "13.0.6",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/npm/node_modules/graceful-fs": {
+            "version": "4.2.11",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/hosted-git-info": {
+            "version": "9.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^11.1.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/http-cache-semantics": {
+            "version": "4.2.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/npm/node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/npm/node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/npm/node_modules/iconv-lite": {
+            "version": "0.7.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/npm/node_modules/ignore-walk": {
+            "version": "8.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minimatch": "^10.0.3"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/ini": {
+            "version": "6.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/init-package-json": {
+            "version": "8.2.5",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/package-json": "^7.0.0",
+                "npm-package-arg": "^13.0.0",
+                "promzard": "^3.0.1",
+                "read": "^5.0.1",
+                "semver": "^7.7.2",
+                "validate-npm-package-name": "^7.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/ip-address": {
+            "version": "10.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/npm/node_modules/is-cidr": {
+            "version": "6.0.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "cidr-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/npm/node_modules/isexe": {
+            "version": "4.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/npm/node_modules/json-parse-even-better-errors": {
+            "version": "5.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/json-stringify-nice": {
+            "version": "1.1.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/npm/node_modules/jsonparse": {
+            "version": "1.3.1",
+            "dev": true,
+            "engines": [
+                "node >= 0.2.0"
+            ],
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/just-diff": {
+            "version": "6.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/just-diff-apply": {
+            "version": "5.5.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/libnpmaccess": {
+            "version": "10.0.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-package-arg": "^13.0.0",
+                "npm-registry-fetch": "^19.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmdiff": {
+            "version": "8.1.5",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/arborist": "^9.4.2",
+                "@npmcli/installed-package-contents": "^4.0.0",
+                "binary-extensions": "^3.0.0",
+                "diff": "^8.0.2",
+                "minimatch": "^10.0.3",
+                "npm-package-arg": "^13.0.0",
+                "pacote": "^21.0.2",
+                "tar": "^7.5.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmexec": {
+            "version": "10.2.5",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@gar/promise-retry": "^1.0.0",
+                "@npmcli/arborist": "^9.4.2",
+                "@npmcli/package-json": "^7.0.0",
+                "@npmcli/run-script": "^10.0.0",
+                "ci-info": "^4.0.0",
+                "npm-package-arg": "^13.0.0",
+                "pacote": "^21.0.2",
+                "proc-log": "^6.0.0",
+                "read": "^5.0.1",
+                "semver": "^7.3.7",
+                "signal-exit": "^4.1.0",
+                "walk-up-path": "^4.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmfund": {
+            "version": "7.0.19",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/arborist": "^9.4.2"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmorg": {
+            "version": "8.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "aproba": "^2.0.0",
+                "npm-registry-fetch": "^19.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmpack": {
+            "version": "9.1.5",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/arborist": "^9.4.2",
+                "@npmcli/run-script": "^10.0.0",
+                "npm-package-arg": "^13.0.0",
+                "pacote": "^21.0.2"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmpublish": {
+            "version": "11.1.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/package-json": "^7.0.0",
+                "ci-info": "^4.0.0",
+                "npm-package-arg": "^13.0.0",
+                "npm-registry-fetch": "^19.0.0",
+                "proc-log": "^6.0.0",
+                "semver": "^7.3.7",
+                "sigstore": "^4.0.0",
+                "ssri": "^13.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmsearch": {
+            "version": "9.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-registry-fetch": "^19.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmteam": {
+            "version": "8.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "aproba": "^2.0.0",
+                "npm-registry-fetch": "^19.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/libnpmversion": {
+            "version": "8.0.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/git": "^7.0.0",
+                "@npmcli/run-script": "^10.0.0",
+                "json-parse-even-better-errors": "^5.0.0",
+                "proc-log": "^6.0.0",
+                "semver": "^7.3.7"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/lru-cache": {
+            "version": "11.2.7",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/npm/node_modules/make-fetch-happen": {
+            "version": "15.0.5",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@gar/promise-retry": "^1.0.0",
+                "@npmcli/agent": "^4.0.0",
+                "@npmcli/redact": "^4.0.0",
+                "cacache": "^20.0.1",
+                "http-cache-semantics": "^4.1.1",
+                "minipass": "^7.0.2",
+                "minipass-fetch": "^5.0.0",
+                "minipass-flush": "^1.0.5",
+                "minipass-pipeline": "^1.2.4",
+                "negotiator": "^1.0.0",
+                "proc-log": "^6.0.0",
+                "ssri": "^13.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/minimatch": {
+            "version": "10.2.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "brace-expansion": "^5.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/npm/node_modules/minipass": {
+            "version": "7.1.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/npm/node_modules/minipass-collect": {
+            "version": "2.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.3"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/npm/node_modules/minipass-fetch": {
+            "version": "5.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^7.0.3",
+                "minipass-sized": "^2.0.0",
+                "minizlib": "^3.0.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            },
+            "optionalDependencies": {
+                "iconv-lite": "^0.7.2"
+            }
+        },
+        "node_modules/npm/node_modules/minipass-flush": {
+            "version": "1.0.5",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
+            "version": "3.3.6",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/minipass-flush/node_modules/yallist": {
+            "version": "4.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/minipass-pipeline": {
+            "version": "1.2.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
+            "version": "3.3.6",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/minipass-pipeline/node_modules/yallist": {
+            "version": "4.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/npm/node_modules/minipass-sized": {
+            "version": "2.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/npm/node_modules/minizlib": {
+            "version": "3.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
+        },
+        "node_modules/npm/node_modules/ms": {
+            "version": "2.1.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/mute-stream": {
+            "version": "3.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/negotiator": {
+            "version": "1.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/npm/node_modules/node-gyp": {
+            "version": "12.2.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "env-paths": "^2.2.0",
+                "exponential-backoff": "^3.1.1",
+                "graceful-fs": "^4.2.6",
+                "make-fetch-happen": "^15.0.0",
+                "nopt": "^9.0.0",
+                "proc-log": "^6.0.0",
+                "semver": "^7.3.5",
+                "tar": "^7.5.4",
+                "tinyglobby": "^0.2.12",
+                "which": "^6.0.0"
+            },
+            "bin": {
+                "node-gyp": "bin/node-gyp.js"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/nopt": {
+            "version": "9.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "abbrev": "^4.0.0"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-audit-report": {
+            "version": "7.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-bundled": {
+            "version": "5.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-normalize-package-bin": "^5.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-install-checks": {
+            "version": "8.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "semver": "^7.1.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-normalize-package-bin": {
+            "version": "5.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-package-arg": {
+            "version": "13.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "hosted-git-info": "^9.0.0",
+                "proc-log": "^6.0.0",
+                "semver": "^7.3.5",
+                "validate-npm-package-name": "^7.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-packlist": {
+            "version": "10.0.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "ignore-walk": "^8.0.0",
+                "proc-log": "^6.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-pick-manifest": {
+            "version": "11.0.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-install-checks": "^8.0.0",
+                "npm-normalize-package-bin": "^5.0.0",
+                "npm-package-arg": "^13.0.0",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-profile": {
+            "version": "12.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "npm-registry-fetch": "^19.0.0",
+                "proc-log": "^6.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-registry-fetch": {
+            "version": "19.1.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@npmcli/redact": "^4.0.0",
+                "jsonparse": "^1.3.1",
+                "make-fetch-happen": "^15.0.0",
+                "minipass": "^7.0.2",
+                "minipass-fetch": "^5.0.0",
+                "minizlib": "^3.0.1",
+                "npm-package-arg": "^13.0.0",
+                "proc-log": "^6.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/npm-user-validate": {
+            "version": "4.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/p-map": {
+            "version": "7.0.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/npm/node_modules/pacote": {
+            "version": "21.5.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "@gar/promise-retry": "^1.0.0",
+                "@npmcli/git": "^7.0.0",
+                "@npmcli/installed-package-contents": "^4.0.0",
+                "@npmcli/package-json": "^7.0.0",
+                "@npmcli/promise-spawn": "^9.0.0",
+                "@npmcli/run-script": "^10.0.0",
+                "cacache": "^20.0.0",
+                "fs-minipass": "^3.0.0",
+                "minipass": "^7.0.2",
+                "npm-package-arg": "^13.0.0",
+                "npm-packlist": "^10.0.1",
+                "npm-pick-manifest": "^11.0.1",
+                "npm-registry-fetch": "^19.0.0",
+                "proc-log": "^6.0.0",
+                "sigstore": "^4.0.0",
+                "ssri": "^13.0.0",
+                "tar": "^7.4.3"
+            },
+            "bin": {
+                "pacote": "bin/index.js"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/parse-conflict-json": {
+            "version": "5.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "json-parse-even-better-errors": "^5.0.0",
+                "just-diff": "^6.0.0",
+                "just-diff-apply": "^5.2.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/path-scurry": {
+            "version": "2.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/npm/node_modules/postcss-selector-parser": {
+            "version": "7.1.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "cssesc": "^3.0.0",
+                "util-deprecate": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/npm/node_modules/proc-log": {
+            "version": "6.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/proggy": {
+            "version": "4.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/promise-all-reject-late": {
+            "version": "1.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/npm/node_modules/promise-call-limit": {
+            "version": "3.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/npm/node_modules/promzard": {
+            "version": "3.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "read": "^5.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
         "node_modules/npm/node_modules/qrcode-terminal": {
             "version": "0.12.0",
             "dev": true,
             "inBundle": true,
             "bin": {
                 "qrcode-terminal": "bin/qrcode-terminal.js"
+            }
+        },
+        "node_modules/npm/node_modules/read": {
+            "version": "5.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "mute-stream": "^3.0.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/read-cmd-shim": {
+            "version": "6.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/npm/node_modules/semver": {
+            "version": "7.7.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/npm/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/npm/node_modules/sigstore": {
+            "version": "4.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@sigstore/bundle": "^4.0.0",
+                "@sigstore/core": "^3.1.0",
+                "@sigstore/protobuf-specs": "^0.5.0",
+                "@sigstore/sign": "^4.1.0",
+                "@sigstore/tuf": "^4.0.1",
+                "@sigstore/verify": "^3.1.0"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/smart-buffer": {
+            "version": "4.2.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6.0.0",
+                "npm": ">= 3.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/socks": {
+            "version": "2.8.7",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ip-address": "^10.0.1",
+                "smart-buffer": "^4.2.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0",
+                "npm": ">= 3.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/socks-proxy-agent": {
+            "version": "8.0.5",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "^4.3.4",
+                "socks": "^2.8.3"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/npm/node_modules/spdx-exceptions": {
@@ -8468,16 +10004,190 @@
             }
         },
         "node_modules/npm/node_modules/spdx-license-ids": {
-            "version": "3.0.20",
+            "version": "3.0.23",
             "dev": true,
             "inBundle": true,
             "license": "CC0-1.0"
+        },
+        "node_modules/npm/node_modules/ssri": {
+            "version": "13.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.3"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/supports-color": {
+            "version": "10.2.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/npm/node_modules/tar": {
+            "version": "7.5.11",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/fs-minipass": "^4.0.0",
+                "chownr": "^3.0.0",
+                "minipass": "^7.1.2",
+                "minizlib": "^3.1.0",
+                "yallist": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/npm/node_modules/text-table": {
             "version": "0.2.0",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
+        },
+        "node_modules/npm/node_modules/tiny-relative-date": {
+            "version": "2.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/tinyglobby": {
+            "version": "0.2.15",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/npm/node_modules/tinyglobby/node_modules/fdir": {
+            "version": "6.5.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
+            "version": "4.0.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/npm/node_modules/treeverse": {
+            "version": "3.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/npm/node_modules/tuf-js": {
+            "version": "4.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "@tufjs/models": "4.1.0",
+                "debug": "^4.4.3",
+                "make-fetch-happen": "^15.0.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/npm/node_modules/validate-npm-package-name": {
+            "version": "7.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/walk-up-path": {
+            "version": "4.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/npm/node_modules/which": {
+            "version": "6.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "isexe": "^4.0.0"
+            },
+            "bin": {
+                "node-which": "bin/which.js"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/write-file-atomic": {
+            "version": "7.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/npm/node_modules/yallist": {
+            "version": "5.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/object-assign": {
             "version": "4.1.1",
@@ -11298,10 +13008,11 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "6.19.8",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-            "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-            "dev": true
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/unicode-emoji-modifier-base": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "oci-token-exchange": "./dist/cli.js"
     },
     "engines": {
-        "node": ">=20"
+        "node": ">=22.14.0"
     },
     "scripts": {
         "build:action": "ncc build src/main.ts -o dist/action --source-map --license licenses.txt",
@@ -72,7 +72,7 @@
         "@semantic-release/npm": "^13.1.5",
         "@semantic-release/release-notes-generator": "^14.1.0",
         "@types/jest": "^29.5.13",
-        "@types/node": "^20.17.11",
+        "@types/node": "^22.0.0",
         "@typescript-eslint/eslint-plugin": "^8.1.0",
         "@typescript-eslint/parser": "^8.1.0",
         "@vercel/ncc": "^0.38.1",


### PR DESCRIPTION
## Summary
- replace Bitbucket source builds with the published npm CLI
- align GitLab and Bitbucket documentation with the supported consumer workflow
- add npm major-family release dist-tags, such as major-v1
- migrate the GitHub Action runtime and CI workflows to Node.js 24
- require Node.js 22.14 or newer for the published CLI
- constrain the release workflow to semantic-release-compatible Node.js versions from 24.10 through 24.x

## Validation
- confirmed the Bitbucket pipeline completed successfully
- validated CI YAML and embedded README YAML examples
- passed all 58 tests on Node.js 22.14 and Node.js 24.18
- completed the full build on Node.js 22.14 and Node.js 24.18
- confirmed rebuilt dist artifacts are unchanged
- confirmed semantic-release 25.0.3 and configured plugins load under Node.js 24.18