### PR TITLE
fix(release): make automated commit pass hooks

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -75,7 +75,7 @@
           "CHANGELOG.md",
           "package.json"
         ],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\nSigned-off-by: semantic-release-bot <semantic-release-bot@users.noreply.github.com>"
       }
     ],
     "@semantic-release/github"


### PR DESCRIPTION
## Summary
- keep generated release notes out of the semantic-release git commit body
- add the required semantic-release-bot Signed-off-by footer
- retain CHANGELOG.md generation and GitHub release notes

## Root cause
The first v2 release attempt correctly calculated 2.0.0 but @semantic-release/git embedded the full generated notes in its commit message. The commit-msg hook rejected a release-note URL longer than 100 characters. No npm 2.0.0 package or v2 GitHub tags were created.

## Validation
- exact generated commit template passes commitlint
- release configuration JSON and git-plugin assets validated
- npm latest remains 1.2.2, beta remains 2.0.0-rc.1, and major-v1 remains 1.2.2