### PR TITLE
fix(release): support protected main branch

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -61,23 +61,7 @@
       }
     ],
     "@semantic-release/release-notes-generator",
-    [
-      "@semantic-release/changelog",
-      {
-        "changelogFile": "CHANGELOG.md"
-      }
-    ],
     "@semantic-release/npm",
-    [
-      "@semantic-release/git",
-      {
-        "assets": [
-          "CHANGELOG.md",
-          "package.json"
-        ],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\nSigned-off-by: semantic-release-bot <semantic-release-bot@users.noreply.github.com>"
-      }
-    ],
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Summary

- remove semantic-release changelog and git plugins that mutate the checkout
- retain npm trusted publishing, generated GitHub release notes, and version tags
- allow the stable release to run without pushing a release commit directly to protected main

## Validation

- release plugin contract validated
- git diff --check
- npm test (58 tests passed)

## Release state

No stable 2.0.0 package or v2 tag was published by the failed runs.