### PR TITLE
chore: merge develop into main

### DIFF
--- a/.github/workflows/published-v2-smoke.yml
+++ b/.github/workflows/published-v2-smoke.yml
@@ -1,0 +1,84 @@
+name: Published v2 Smoke Test
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 9 * * 1"
+  workflow_run:
+    workflows:
+      - Release
+    types:
+      - completed
+    branches:
+      - main
+
+concurrency:
+  group: published-v2-smoke
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    name: Test published v2 action
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (
+        github.event.workflow_run.event == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success'
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Install OCI CLI
+        run: |
+          curl -L https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh |
+            bash -s -- --accept-all-defaults
+          echo "$HOME/bin" >> "$GITHUB_PATH"
+        shell: bash
+
+      # Deliberately omit checkout, setup-node, npm install, and build steps.
+      # This exercises the published action in the same way as an external consumer.
+      - name: Run published v2 action
+        id: token_exchange
+        uses: gtrevorrow/oci-token-exchange-action@v2
+        with:
+          oidc_client_identifier: ${{ secrets.OIDC_CLIENT_IDENTIFIER }}
+          domain_base_url: ${{ vars.DOMAIN_BASE_URL }}
+          oci_tenancy: ${{ vars.OCI_TENANCY }}
+          oci_region: ${{ vars.OCI_REGION }}
+          oci_home: ${{ runner.temp }}/published-v2-smoke
+          oci_profile: PUBLISHED_V2_SMOKE
+          retry_count: "3"
+
+      - name: Validate generated credentials and OCI access
+        env:
+          OCI_CONFIG_PATH: ${{ steps.token_exchange.outputs.oci_config_path }}
+          OCI_SESSION_TOKEN_PATH: ${{ steps.token_exchange.outputs.oci_session_token_path }}
+          OCI_PRIVATE_KEY_PATH: ${{ steps.token_exchange.outputs.oci_private_key_path }}
+        run: |
+          set -euo pipefail
+
+          for artifact in \
+            "$OCI_CONFIG_PATH" \
+            "$OCI_SESSION_TOKEN_PATH" \
+            "$OCI_PRIVATE_KEY_PATH"
+          do
+            if [[ -z "$artifact" || ! -f "$artifact" ]]; then
+              echo "::error::Expected credential artifact was not created: $artifact"
+              exit 1
+            fi
+
+            mode="$(stat -c '%a' "$artifact")"
+            if [[ "$mode" != "600" ]]; then
+              echo "::error::Expected $artifact to have mode 600, but found $mode"
+              exit 1
+            fi
+          done
+
+          oci \
+            --auth security_token \
+            --config-file "$OCI_CONFIG_PATH" \
+            --profile PUBLISHED_V2_SMOKE \
+            os ns get
+        shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,14 +88,20 @@ jobs:
           fi
           echo "--- End of semantic-release-error.log content ---"
           
-          # Always output semantic-release output for debugging
-          echo "--- semantic-release-output.json content ---"
-          if [ -f semantic-release-output.json ]; then
-            cat semantic-release-output.json
+          # Log a compact summary instead of the full semantic-release result,
+          # which can contain the entire commit history and release notes.
+          echo "--- semantic-release result summary ---"
+          if [ -s semantic-release-output.json ] && jq -e . semantic-release-output.json > /dev/null 2>&1; then
+            jq '{
+              nextRelease: (.nextRelease | {type, version, gitTag}),
+              releases: [.releases[]? | {name, version, gitTag, url, pluginName}]
+            }' semantic-release-output.json
+          elif [ -s semantic-release-output.json ]; then
+            echo "semantic-release-output.json is not valid JSON."
           else
-            echo "semantic-release-output.json does not exist."
+            echo "semantic-release-output.json does not exist or is empty."
           fi
-          echo "--- End of semantic-release-output.json content ---"
+          echo "--- End of semantic-release result summary ---"
           
           if [ "$SCRIPT_EXIT_CODE" -eq 1 ]; then
             echo "::error::Semantic release script failed. See logs above for details."
@@ -109,21 +115,6 @@ jobs:
         id: sr_outputs
         run: |
           echo "--- Debug: Script Exit Code was: ${{ env.SCRIPT_EXIT_CODE }} ---"
-          echo "--- Debug: Content of semantic-release-output.json (after programmatic run) ---"
-          if [ -f semantic-release-output.json ]; then
-            cat semantic-release-output.json
-          else
-            echo "semantic-release-output.json does NOT exist."
-          fi
-          echo "--- End of content ---"
-
-          echo "--- Debug: Content of semantic-release-error.log ---"
-          if [ -f semantic-release-error.log ]; then
-            cat semantic-release-error.log
-          else
-            echo "semantic-release-error.log does NOT exist."
-          fi
-          echo "--- End of error log content ---"
 
           if [ "${{ env.SCRIPT_EXIT_CODE }}" -eq 0 ]; then
             # Exit code 0 means a release was made and JSON should be in semantic-release-output.json
@@ -131,59 +122,37 @@ jobs:
               echo "::error::semantic-release-output.json does not exist or is empty, but script exited with 0 (expected release)."
               echo "new_release_published=false" >> $GITHUB_OUTPUT
               echo "new_release_version=" >> $GITHUB_OUTPUT
-              echo "new_release_notes=" >> $GITHUB_OUTPUT
               exit 1 # Fail the step as this is an inconsistent state
             fi
 
-            JSON_OUTPUT=$(cat semantic-release-output.json)
-            if echo "$JSON_OUTPUT" | jq -e . > /dev/null; then
-              echo "Successfully validated JSON from semantic-release-output.json."
-              echo "--- JSON content ---"
-              echo "$JSON_OUTPUT"
-              echo "--- End of JSON content ---"
-
-              VERSION=$(echo "$JSON_OUTPUT" | jq -r '.nextRelease.version // ""')
-              NOTES_RAW=$(echo "$JSON_OUTPUT" | jq -r '.nextRelease.notes // ""')
-              
-              if [ -n "$VERSION" ]; then
-                echo "new_release_published=true" >> $GITHUB_OUTPUT
-                echo "new_release_version=$VERSION" >> $GITHUB_OUTPUT
-                
-                # Ensure notes are properly escaped for multiline output
-                {
-                  echo "new_release_notes<<EOF_NOTES"
-                  echo "$NOTES_RAW"
-                  echo "EOF_NOTES"
-                } >> $GITHUB_OUTPUT
-
-                echo "Successfully parsed release information: Version $VERSION"
-              else
-                echo "::warning::Script exited 0 (release expected) but no new release version found in JSON (.nextRelease.version was empty or null)."
-                echo "new_release_published=false" >> $GITHUB_OUTPUT
-                echo "new_release_version=" >> $GITHUB_OUTPUT
-                echo "new_release_notes=" >> $GITHUB_OUTPUT
-              fi
-            else
+            if ! jq -e . semantic-release-output.json > /dev/null; then
               echo "::error::Failed to validate semantic-release-output.json as JSON, but script exited with 0."
-              echo "File content was:"
-              cat semantic-release-output.json
               echo "new_release_published=false" >> $GITHUB_OUTPUT
               echo "new_release_version=" >> $GITHUB_OUTPUT
-              echo "new_release_notes=" >> $GITHUB_OUTPUT
               exit 1 # Fail the step
             fi
+
+            VERSION=$(jq -r '.nextRelease.version // empty' semantic-release-output.json)
+            if [ -z "$VERSION" ]; then
+              echo "::error::Script exited 0 (release expected) but .nextRelease.version was empty."
+              echo "new_release_published=false" >> $GITHUB_OUTPUT
+              echo "new_release_version=" >> $GITHUB_OUTPUT
+              exit 1
+            fi
+
+            echo "new_release_published=true" >> $GITHUB_OUTPUT
+            echo "new_release_version=$VERSION" >> $GITHUB_OUTPUT
+            echo "Successfully parsed release information: Version $VERSION"
           elif [ "${{ env.SCRIPT_EXIT_CODE }}" -eq 2 ]; then
             # Exit code 2 means no release was made
             echo "No new release published (script exit code 2)."
             echo "new_release_published=false" >> $GITHUB_OUTPUT
             echo "new_release_version=" >> $GITHUB_OUTPUT
-            echo "new_release_notes=" >> $GITHUB_OUTPUT
           else
             # This case should ideally not be reached if the previous step correctly exits on SCRIPT_EXIT_CODE=1
             echo "::error::Unexpected script exit code: ${{ env.SCRIPT_EXIT_CODE }}. Expected 0 (release) or 2 (no release)."
             echo "new_release_published=false" >> $GITHUB_OUTPUT
             echo "new_release_version=" >> $GITHUB_OUTPUT
-            echo "new_release_notes=" >> $GITHUB_OUTPUT
             exit 1 # Fail the step
           fi
         shell: bash
@@ -212,8 +181,6 @@ jobs:
           echo "Semantic Release Outputs (from sr_outputs step):"
           echo "new_release_published: $NEW_RELEASE_PUBLISHED"
           echo "new_release_version: $NEW_RELEASE_VERSION"
-          # Notes can contain special characters, so we'll just check if they exist
-          echo "new_release_notes: [notes available but not displayed due to special characters]"
 
       # Add steps to update major version tag
       - name: Update Major Version Tag (e.g., v1)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - [Installation](#installation)
   - [As GitHub Action](#as-github-action)
   - [As CLI Tool](#as-cli-tool)
+- [Migrating from v1 to v2](#migrating-from-v1-to-v2)
 - [Usage](#usage)
   - [Inputs And Outputs](#inputs-and-outputs)
   - [GitHub Actions](#github-actions)
@@ -30,8 +31,8 @@ A tool to exchange OIDC tokens for [OCI session tokens](https://docs.oracle.com/
 
 To use this tool as a step in your GitHub Actions workflow, reference it using a specific Git tag, commit SHA, or branch. The following options are available, managed automatically by the release workflow:
 
-*   **`@vX` (e.g., `@v1`) - Recommended:** Points to the latest stable release within a specific major version (e.g., the latest `v1.x.y`). This tag is automatically updated upon new releases, allowing you to receive compatible updates and bug fixes without breaking changes.
-*   **`@vX.Y.Z` (e.g., `@v1.1.0`) - Specific Version:** Pins the action to an exact release version created by semantic-release. Use this if you need absolute stability and want to control updates manually.
+*   **`@vX` (e.g., `@v2`) - Recommended:** Points to the latest stable release within a specific major version (e.g., the latest `v2.x.y`). This tag is automatically updated upon new releases, allowing you to receive compatible updates and bug fixes without breaking changes.
+*   **`@vX.Y.Z` (e.g., `@v2.0.0`) - Specific Version:** Pins the action to an exact release version created by semantic-release. Use this if you need absolute stability and want to control updates manually.
 *   **`@<full-commit-sha>` - Highest Integrity Pinning:** Pins to a single immutable commit. Use this for high-assurance production pipelines and strict supply-chain controls.
 *   **`@latest` - Latest Release:** Points to the most recent release. This tag is automatically updated upon new releases by the release workflow.
 *   **`@main` - Bleeding Edge (Not Recommended):** Runs the action directly from the latest commit on the `main` branch. This is unstable and should generally be avoided in production workflows.
@@ -43,10 +44,10 @@ Pinning guidance:
 
 ```yaml
 # Recommended: Use the major version tag for automatic compatible updates
-- uses: gtrevorrow/oci-token-exchange-action@v1
+- uses: gtrevorrow/oci-token-exchange-action@v2
 
-# Alternative: Pin to a specific version (e.g., v1.1.0)
-# - uses: gtrevorrow/oci-token-exchange-action@v1.1.0 
+# Alternative: Pin to a specific version (e.g., v2.0.0)
+# - uses: gtrevorrow/oci-token-exchange-action@v2.0.0
 
 # Highest integrity: Pin to an exact commit SHA
 # - uses: gtrevorrow/oci-token-exchange-action@<full-commit-sha>
@@ -65,8 +66,58 @@ npm install -g @gtrevorrow/oci-token-exchange@<release-tag>
 ```
 
 Stable releases are published with the `latest` npm dist-tag. Major-family
-dist-tags such as `major-v1` are maintained manually after a release. For an
-immutable installation, use an exact package version.
+dist-tags such as `major-v1` and `major-v2` are maintained manually after a
+release. For an immutable installation, use an exact package version.
+
+## Migrating from v1 to v2
+
+For most users, the only required change is the release tag. Existing consumers
+pinned to the GitHub Action `@v1` or npm `major-v1` remain on v1.2.2.
+
+### GitHub Actions
+
+Test the immutable v2 release first:
+
+```yaml
+- uses: gtrevorrow/oci-token-exchange-action@v2.0.0
+```
+
+After validation, follow compatible v2 updates with:
+
+```yaml
+- uses: gtrevorrow/oci-token-exchange-action@v2
+```
+
+The standard action inputs are unchanged.
+
+### npm CLI, GitLab CI, and Bitbucket Pipelines
+
+Test the immutable package version first:
+
+```bash
+npm install @gtrevorrow/oci-token-exchange@2.0.0
+```
+
+After validation, follow compatible v2 updates with:
+
+```bash
+npm install @gtrevorrow/oci-token-exchange@major-v2
+```
+
+The standard GitLab and Bitbucket environment variables are unchanged.
+
+### Library API changes
+
+Consumers importing the package API must apply these renames:
+
+- `tokenExchangeJwtToUpst` to `tokenExchange`
+- `UpstTokenResponse` to `TokenExchangeResponse`
+- `OciConfig.upstToken` to `OciConfig.sessionToken`
+
+### OCI profile validation
+
+`oci_profile` values containing path separators are now rejected. Replace such
+values with a safe profile name such as `DEFAULT` or `CI` before upgrading.
 
 ## Usage
 
@@ -147,7 +198,7 @@ Variable resolution differs between GitHub Actions and CLI/non-GitHub usage:
 Use the example below together with the [Inputs and Outputs](#inputs-and-outputs) reference above.
 
 ```yaml
-- uses: gtrevorrow/oci-token-exchange-action@v1
+- uses: gtrevorrow/oci-token-exchange-action@v2
   with:
     # ci_platform: 'github' # Optional: Defaults to 'github'. Other values: 'gitlab', 'bitbucket', 'local' (though 'github' is typical for Actions)
     oidc_client_identifier: ${{ secrets.OIDC_CLIENT_IDENTIFIER }} 


### PR DESCRIPTION
## Summary

- promote the release-output parsing fix from develop
- publish the v2 migration guidance on the default branch
- add the consumer-style published `@v2` smoke-test workflow

## Release impact

No new semantic version is expected. The unreleased conventional commits are `ci`, `docs`, and `test`, all of which are configured with `release: false`.

The existing npm `latest` version and GitHub `v2`, `v2.0.0`, and `latest` tags should remain unchanged.

## Validation

- PRs #79, #80, and #81 passed their required build and CodeQL checks
- PR #81 additionally passed 58 local tests, a full build, formatting, and whitespace validation
- after merge, the new workflow will invoke `gtrevorrow/oci-token-exchange-action@v2` without checkout, Node setup, npm installation, or a local build, then perform a real OCI request